### PR TITLE
change architect version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  architect: giantswarm/architect@4.24.0
+  architect: giantswarm/architect@4.28.1
 
 workflows:
   build:


### PR DESCRIPTION
Changing architect version to a newer one to try out the `align files` jobs as it was failing until now due to 403 error : https://github.com/giantswarm/github/actions/runs/4540400921/jobs/8001278399