### PR TITLE
Configure gsoci.azurecr.io as the registry to use by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Configure `gsoci.azurecr.io` as the default container image registry.
+
 ## [1.2.1] - 2023-06-27
 
 ### Fixed
@@ -58,12 +62,6 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 - Automatically generated base files
 - Values schema
-
-## [0.11.0-gs2] - 2023-02-20
-
-### Added
-
-- Add modified grafana dashboards.
 
 ## [0.11.0-gs1] - 2023-02-20
 

--- a/helm/sloth/values.yaml
+++ b/helm/sloth/values.yaml
@@ -1,7 +1,7 @@
 labels: {}
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   repository: giantswarm/sloth
   tag: v0.11.0
 
@@ -34,7 +34,7 @@ sloth:
 commonPlugins:
   enabled: true
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/git-sync
     tag: v4.1.0
   gitRepo:


### PR DESCRIPTION
Towards

- https://github.com/giantswarm/roadmap/issues/3017

This PR replaces any occurrence of `docker.io` in `values.yaml` files with `gsoci.azurecr.io`,
to make the new ACR registry the default one.
