### PR TITLE
Fix sloth issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix issues related to git-sync since upgrade to [4.x.x](https://github.com/kubernetes/git-sync/releases/tag/v4.0.0).
+
+### Changed
+
+- Configure gsoci.azurecr.io as the default container image registry.
+
 ## [1.3.0] - 2024-01-23
 
 ### Added

--- a/helm/sloth/templates/deployment.yaml
+++ b/helm/sloth/templates/deployment.yaml
@@ -93,13 +93,13 @@ spec:
           image: {{ .Values.commonPlugins.image.registry }}/{{ .Values.commonPlugins.image.repository }}:{{ .Values.commonPlugins.image.tag }}
           args:
             - --repo={{.Values.commonPlugins.gitRepo.url}}
-            - --branch={{.Values.commonPlugins.gitRepo.branch}}
-            - --wait=30
+            - --ref={{.Values.commonPlugins.gitRepo.ref}}
+            - --period=30s
             - --webhook-url=http://localhost:8082/-/reload
           volumeMounts:
             - name: sloth-common-sli-plugins
               # Default path for git-sync.
-              mountPath: /tmp/git
+              mountPath: /git
           {{- with .Values.securityContext.container }}
           securityContext:
             {{- toYaml . | nindent 12 }}

--- a/helm/sloth/values.schema.json
+++ b/helm/sloth/values.schema.json
@@ -19,7 +19,7 @@
                 "gitRepo": {
                     "type": "object",
                     "properties": {
-                        "branch": {
+                        "ref": {
                             "type": "string"
                         },
                         "resources": {

--- a/helm/sloth/values.yaml
+++ b/helm/sloth/values.yaml
@@ -1,7 +1,7 @@
 labels: {}
 
 image:
-  registry: docker.io
+  registry: gsoci.azurecr.io
   repository: giantswarm/sloth
   tag: v0.11.0
 
@@ -37,12 +37,12 @@ sloth:
 commonPlugins:
   enabled: true
   image:
-    registry: docker.io
+    registry: gsoci.azurecr.io
     repository: giantswarm/git-sync
     tag: v4.2.0
   gitRepo:
     url: https://github.com/slok/sloth-common-sli-plugins
-    branch: main
+    ref: main
     resources:
       limits:
         cpu: 50m


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/29640 

This PR fixes git-sync root path as it was changed when upgrading to git-sync 4.0.0.

This PR also changes the registry to the new giantswarm one