### PR TITLE
Rename sloth dashboards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Rename Sloth dashboards to align with the new SLA reporting dashboard.
+
 ## [1.4.0] - 2024-01-29
 
 ### Fixed

--- a/helm/sloth/templates/grafana-dashboard-sloth-overview.yaml
+++ b/helm/sloth/templates/grafana-dashboard-sloth-overview.yaml
@@ -931,8 +931,8 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "Sloth SLO Overview",
-      "uid": "high-level-sloth-slos",
+      "title": "SLOs / Sloth Overview",
+      "uid": "slo-overview",
       "version": 3,
       "weekStart": ""
     }

--- a/helm/sloth/templates/grafana-dashboard-sloth.yaml
+++ b/helm/sloth/templates/grafana-dashboard-sloth.yaml
@@ -1537,7 +1537,7 @@ data:
       },
       "timepicker": {},
       "timezone": "",
-      "title": "Sloth SLO",
+      "title": "SLOs / Sloth",
       "uid": "slo-detail",
       "version": 14,
       "weekStart": ""


### PR DESCRIPTION
Towards https://github.com/giantswarm/dashboards/pull/433, aligning naming of dashboards