### PR TITLE
dashboard: update annotations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Update dashboards for observability-op provisioning.
+
 ### Added
 
 - Add helm chart templating test in ci pipeline.

--- a/customizations/templates/grafana-dashboard-sloth-overview.yaml
+++ b/customizations/templates/grafana-dashboard-sloth-overview.yaml
@@ -3,7 +3,10 @@ kind: ConfigMap
 metadata:
   annotations:
     ## Define the directory in grafana where the dashboard will be added to the grafana container
+    # TODO: remove this label when deprecate vintage installations
     k8s-sidecar-target-directory: /var/lib/grafana/dashboards/private/shared
+    ## Load dashboard in "Shared Org" grafana organization
+    observability.giantswarm.io/organization: "Shared Org"
   labels:
     {{- include "sloth.labels" . | nindent 4 }}
     app.giantswarm.io/kind: dashboard

--- a/customizations/templates/grafana-dashboard-sloth.yaml
+++ b/customizations/templates/grafana-dashboard-sloth.yaml
@@ -3,7 +3,10 @@ kind: ConfigMap
 metadata:
   annotations:
     ## Define the directory in grafana where the dashboard will be added to the grafana container
+    # TODO: remove this label when deprecate vintage installations
     k8s-sidecar-target-directory: /var/lib/grafana/dashboards/private/shared
+    ## Load dashboard in "Shared Org" grafana organization
+    observability.giantswarm.io/organization: "Shared Org"
   labels:
     {{- include "sloth.labels" . | nindent 4 }}
     app.giantswarm.io/kind: dashboard

--- a/helm/sloth/templates/grafana-dashboard-sloth-overview.yaml
+++ b/helm/sloth/templates/grafana-dashboard-sloth-overview.yaml
@@ -3,7 +3,10 @@ kind: ConfigMap
 metadata:
   annotations:
     ## Define the directory in grafana where the dashboard will be added to the grafana container
+    # TODO: remove this label when deprecate vintage installations
     k8s-sidecar-target-directory: /var/lib/grafana/dashboards/private/shared
+    ## Load dashboard in "Shared Org" grafana organization
+    observability.giantswarm.io/organization: "Shared Org"
   labels:
     {{- include "sloth.labels" . | nindent 4 }}
     app.giantswarm.io/kind: dashboard

--- a/helm/sloth/templates/grafana-dashboard-sloth.yaml
+++ b/helm/sloth/templates/grafana-dashboard-sloth.yaml
@@ -3,7 +3,10 @@ kind: ConfigMap
 metadata:
   annotations:
     ## Define the directory in grafana where the dashboard will be added to the grafana container
+    # TODO: remove this label when deprecate vintage installations
     k8s-sidecar-target-directory: /var/lib/grafana/dashboards/private/shared
+    ## Load dashboard in "Shared Org" grafana organization
+    observability.giantswarm.io/organization: "Shared Org"
   labels:
     {{- include "sloth.labels" . | nindent 4 }}
     app.giantswarm.io/kind: dashboard


### PR DESCRIPTION
Towards https://github.com/giantswarm/roadmap/issues/3696

This PR updates the dashboard for the multi-tenant dashboards provisioning.

Note: the new annotations will work on CAPI clusters, but not on vintage clusters.
So we kept the old annotation for vintage clusters.
This will generate provisioning errors until we disable the grafana dashboard provisioning sidecar on CAPI installations.