### PR TITLE
Fix circleci so that push to collection works again

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,19 +17,23 @@ jobs:
 workflows:
   build:
     jobs:
+    # Ensure that for every commit to main and for every
+    # release tag triggers the build
     - template-chart:
         name: template-chart-test
         filters:
+          tags:
+            only: /^v.*/
           branches:
             ignore:
             - main
 
-      # Ensure that for every commit to master and for every
-      # release tag, there is an app version in the catalog.
     - architect/push-to-app-catalog:
         context: architect
         executor: app-build-suite
         name: package-and-push-chart
+        requires:
+        - template-chart-test
         app_catalog: control-plane-catalog
         app_catalog_test: control-plane-test-catalog
         chart: sloth
@@ -46,6 +50,8 @@ workflows:
         requires:
         - package-and-push-chart
         filters:
+          tags:
+            only: /^v.*/
           branches:
             ignore:
             - main
@@ -58,7 +64,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: aws-app-collection
         requires:
-        - package-and-push-chart
+        - run-tests-with-ats
         filters:
           branches:
             ignore: /.*/
@@ -73,7 +79,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: vsphere-app-collection
         requires:
-        - package-and-push-chart
+        - run-tests-with-ats
         filters:
           branches:
             ignore: /.*/
@@ -88,7 +94,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: cloud-director-app-collection
         requires:
-        - package-and-push-chart
+        - run-tests-with-ats
         filters:
           branches:
             ignore: /.*/
@@ -103,7 +109,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: capa-app-collection
         requires:
-        - package-and-push-chart
+        - run-tests-with-ats
         filters:
           branches:
             ignore: /.*/
@@ -118,7 +124,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: capz-app-collection
         requires:
-        - package-and-push-chart
+        - run-tests-with-ats
         filters:
           branches:
             ignore: /.*/
@@ -133,7 +139,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: proxmox-app-collection
         requires:
-        - package-and-push-chart
+        - run-tests-with-ats
         filters:
           branches:
             ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,16 +37,12 @@ workflows:
         filters:
           tags:
             only: /^v.*/
-
           branches:
             ignore:
             - main
-            - master
+
     - architect/run-tests-with-ats:
         name: run-tests-with-ats
-          ## TODO Remove once new architect orb is released
-        app-test-suite_version: v0.8.0
-        app-test-suite_container_tag: 0.8.0
         requires:
         - package-and-push-chart
         filters:
@@ -55,14 +51,14 @@ workflows:
             - main
 
     - architect/push-to-app-collection:
-        name: aws-app-collection
         context: architect
+        name: push-to-aws-app-collection
         app_catalog: control-plane-catalog
         app_name: sloth
         app_namespace: monitoring
         app_collection_repo: aws-app-collection
         requires:
-        - run-tests-with-ats
+        - package-and-push-chart
         filters:
           branches:
             ignore: /.*/
@@ -70,14 +66,14 @@ workflows:
             only: /^v.*/
 
     - architect/push-to-app-collection:
-        name: vsphere-app-collection
         context: architect
+        name: push-to-vsphere-app-collection
         app_catalog: control-plane-catalog
         app_name: sloth
         app_namespace: monitoring
         app_collection_repo: vsphere-app-collection
         requires:
-        - run-tests-with-ats
+        - package-and-push-chart
         filters:
           branches:
             ignore: /.*/
@@ -92,7 +88,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: cloud-director-app-collection
         requires:
-        - run-tests-with-ats
+        - package-and-push-chart
         filters:
           branches:
             ignore: /.*/
@@ -107,7 +103,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: capa-app-collection
         requires:
-        - run-tests-with-ats
+        - package-and-push-chart
         filters:
           branches:
             ignore: /.*/
@@ -122,7 +118,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: capz-app-collection
         requires:
-        - run-tests-with-ats
+        - package-and-push-chart
         filters:
           branches:
             ignore: /.*/
@@ -137,7 +133,7 @@ workflows:
         app_namespace: monitoring
         app_collection_repo: proxmox-app-collection
         requires:
-        - run-tests-with-ats
+        - package-and-push-chart
         filters:
           branches:
             ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,6 +47,9 @@ workflows:
 
     - architect/run-tests-with-ats:
         name: run-tests-with-ats
+        ## TODO Remove once new architect orb is released
+        app-test-suite_version: v0.8.0
+        app-test-suite_container_tag: 0.8.0
         requires:
         - package-and-push-chart
         filters:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Push to collection CI.
+
 ## [1.5.0] - 2025-02-13
 
 ### Changed


### PR DESCRIPTION
The sloth dashboards with the organization labels were never deployed on MCs because CI was silently not working. This fixes it