### PR TITLE
fix: fix ABS override_app_version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,7 @@ workflows:
         app_catalog_test: control-plane-test-catalog
         chart: sloth
         persist_chart_archive: true
+        override_app_version: false
         filters:
           tags:
             only: /^v.*/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- Fix ABS config to not override AppVersion in Chart.yaml
+
 ## [1.9.1] - 2026-02-12
 
 ### Changed


### PR DESCRIPTION
In recent versions, ABS and architect orb changed the default behaviour for overriding the AppVersion in Chart.yaml when building and pushing charts. Now the default is to override it.
This does not work for this chart, since we use an upstream image with a different version than the chart itself.